### PR TITLE
add cmd : v8 source list

### DIFF
--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -113,6 +113,7 @@ bool PrintCmd::DoExecute(SBDebugger d, char** cmd,
   return true;
 }
 
+
 bool CodeMap::DoExecute(SBDebugger d, char** cmd,
                         SBCommandReturnObject& result) {
   SBTarget target = d.GetSelectedTarget();
@@ -134,6 +135,92 @@ bool CodeMap::DoExecute(SBDebugger d, char** cmd,
 
   result.Printf("%s\n", res.c_str());
 
+  return true;
+}
+
+
+bool ListCmd::DoExecute(SBDebugger d, char** cmd,
+                         SBCommandReturnObject& result) {
+  static SBFrame last_frame;
+  static uint64_t last_line = 0;
+  SBTarget target = d.GetSelectedTarget();
+  SBThread thread = target.GetProcess().GetSelectedThread();
+  if (!thread.IsValid()) {
+    result.SetError("No valid process, please start something\n");
+    return false;
+  }
+
+  std::string full_cmd;
+  bool grab_line = false;
+  bool line_switch = false;
+  int line_from_switch = 0;
+  for (char** start = cmd; *start != nullptr; start++) {
+    if (grab_line) {
+      grab_line = false;
+      line_switch = true;
+      errno = 0;
+      line_from_switch = strtol(*start, nullptr, 10);
+      if (errno) {
+        result.SetError("Invalid line number");
+        return false;
+      }
+      line_from_switch--;
+    }
+    if (strcmp(*start, "-l") == 0) {
+      grab_line = true;
+    }
+    full_cmd += *start;
+  }
+  if (grab_line || (line_switch && line_from_switch < 0)) {
+    result.SetError("Expected line number after -l");
+    return false;
+  }
+
+  // Load V8 constants from postmortem data
+  llv8.Load(target);
+  SBFrame frame = thread.GetSelectedFrame();
+  SBSymbol symbol = frame.GetSymbol();
+  
+  bool reset_line = false;
+  if (line_switch) {
+    reset_line = true;
+    last_line = line_from_switch;
+  }
+  else if (frame != last_frame) {
+    last_line = 0;
+    reset_line = true;
+  }
+  last_frame = frame;
+  // C++ symbol
+  if (symbol.IsValid()) {
+    SBCommandInterpreter interpreter = d.GetCommandInterpreter();
+    std::string cmd = "source list ";
+    cmd += full_cmd;
+    interpreter.HandleCommand(cmd.c_str(), result, false);
+    return true;
+  }
+  
+  // V8 frame
+  v8::Error err;
+  v8::JSFrame v8_frame(&llv8, static_cast<int64_t>(frame.GetFP()));
+  
+  const static uint32_t kDisplayLines = 4;
+  std::string* lines = new std::string[kDisplayLines];
+  uint32_t lines_found = 0;
+  
+  uint32_t line_cursor = v8_frame.GetSourceForDisplay(
+                              reset_line, last_line, kDisplayLines,
+                              lines, lines_found, err);
+  if (err.Fail()) {
+    result.SetError(err.GetMessage());
+    return false;
+  }
+  last_line = line_cursor;
+
+  for (uint32_t i = 0; i < lines_found; i++) {
+    result.Printf("  %d %s\n", line_cursor - lines_found + i + 1, lines[i].c_str());
+  }
+  
   return true;
 }
 
@@ -160,6 +247,10 @@ bool PluginInitialize(SBDebugger d) {
   v8.AddCommand("inspect", new llnode::PrintCmd(true),
       "Print detailed description and contents of the JavaScript value.\n\n"
       "Syntax: v8 inspect expr\n");
+  SBCommand source = v8.AddMultiwordCommand("source", "Source code information");
+  source.AddCommand("list", new llnode::ListCmd(),
+      "Print source lines around a selected JavaScript frame.\n\n"
+      "Syntax: v8 list\n");
 
   v8.AddCommand("code-map", new llnode::CodeMap(),
       "Print code map of all compiled functions.\n\n"

--- a/src/llnode.h
+++ b/src/llnode.h
@@ -40,6 +40,15 @@ class CodeMap : public lldb::SBCommandPluginInterface {
                  lldb::SBCommandReturnObject& result) override;
 };
 
+class ListCmd : public lldb::SBCommandPluginInterface {
+ public:
+  ~ListCmd() override {
+  }
+
+  bool DoExecute(lldb::SBDebugger d, char** cmd,
+                 lldb::SBCommandReturnObject& result) override;
+};
+
 }  // namespace llnode
 
 #endif  // SRC_LLNODE_H_

--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -87,6 +87,12 @@ inline int64_t Map::GetType(Error& err) {
 }
 
 
+inline JSFunction JSFrame::GetFunction(Error& err) {
+  return v8()->LoadValue<JSFunction>(
+      raw() + v8()->frame()->kFunctionOffset, err);
+}
+
+
 inline int64_t JSFrame::LeaParamSlot(int slot, int count) const {
   return raw() + v8()->frame()->kArgsOffset +
       (count - slot - 1) * v8()->common()->kPointerSize;

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -141,6 +141,54 @@ uint8_t* LLV8::LoadChunk(int64_t addr, int64_t length, Error& err) {
   return buf;
 }
 
+// reset_line - make line_start absolute vs start of function
+//            otherwise relative to last end
+// returns line cursor
+uint32_t JSFrame::GetSourceForDisplay(bool reset_line, uint32_t line_start,
+                                  uint32_t line_limit, std::string lines[],
+                                  uint32_t& lines_found, Error& err) {
+  
+  v8::JSFunction fn = GetFunction(err);
+  if (err.Fail()) {
+    return line_start;
+  }
+  
+  v8::SharedFunctionInfo info = fn.Info(err);
+  if (err.Fail()) {
+    return line_start;
+  }
+  
+  v8::Script script = info.GetScript(err);
+  if (err.Fail()) {
+    return line_start;
+  }
+  
+  // Check if this is being run multiple times against the same frame
+  // if not, reset last line
+  if (reset_line) {
+    uint32_t pos = info.StartPosition(err);
+    if (err.Fail()) {
+      return line_start;
+    }
+    int64_t tmp_line;
+    int64_t tmp_col;
+    script.GetLineColumnFromPos(pos, tmp_line, tmp_col, err);
+    if (err.Fail()) {
+      return line_start;
+    }
+    line_start += tmp_line;
+  }
+  
+  script.GetLines(line_start, lines, line_limit, lines_found, err);
+  if (err.Fail()) {
+    const char* msg = err.GetMessage();
+    if (msg == nullptr) {
+      err = Error(true, "Failed to get Function Source");
+    }
+    return line_start;
+  }
+  return line_start + lines_found;
+}
 
 std::string JSFrame::Inspect(bool with_args, Error& err) {
   Value context =
@@ -178,8 +226,7 @@ std::string JSFrame::Inspect(bool with_args, Error& err) {
   }
 
   // We are dealing with function or internal code (probably stub)
-  JSFunction fn =
-      v8()->LoadValue<JSFunction>(raw() + v8()->frame()->kFunctionOffset, err);
+  JSFunction fn = GetFunction(err);
   if (err.Fail()) return std::string();
 
   int64_t fn_type = fn.GetType(err);
@@ -337,10 +384,15 @@ std::string SharedFunctionInfo::GetPostfix(Error& err) {
   if (res.empty())
     res = "(no script)";
 
-  res += script.GetLineColumnFromPos(start_pos, err);
+  int64_t line = 0;
+  int64_t column = 0;
+  script.GetLineColumnFromPos(start_pos, line, column, err);
   if (err.Fail()) return std::string();
 
-  return res;
+  char tmp[128];
+  snprintf(tmp, sizeof(tmp), ":%d:%d", static_cast<int>(line),
+      static_cast<int>(column));
+  return res + tmp;
 }
 
 
@@ -352,19 +404,71 @@ std::string SharedFunctionInfo::ToString(Error& err) {
 }
 
 
-std::string Script::GetLineColumnFromPos(int64_t pos, Error& err) {
-  char tmp[128];
-
+// return end_char+1, which may be less than line_limit if source
+// ends before end_inclusive
+void Script::GetLines(uint64_t start_line, std::string lines[],
+                          uint64_t line_limit, uint32_t &lines_found,
+                          Error& err) {
+  lines_found = 0;
+  
   HeapObject source = Source(err);
-  if (err.Fail()) return std::string();
+  if (err.Fail()) return;
 
   int64_t type = source.GetType(err);
-  if (err.Fail()) return std::string();
+  if (err.Fail()) return;
 
   // No source
   if (type > v8()->types()->kFirstNonstringType) {
-    snprintf(tmp, sizeof(tmp), ":0:%d", static_cast<int>(pos));
-    return tmp;
+    err = Error(true, "No source");
+    return;
+  }
+
+  String str(source);
+  std::string source_str = str.ToString(err);
+  uint64_t limit = source_str.length();
+
+  uint64_t length = 0;
+  uint64_t line_i = 0;
+  uint64_t i = 0;
+  for (; i < limit && lines_found < line_limit; i++) {
+    // \r\n should ski adding a line and column on \r
+    if (source_str[i] == '\r' && i < limit - 1 && source_str[i + 1] == '\n') {
+      i++;
+    }
+    if (source_str[i] == '\n' || source_str[i] == '\r') {
+      if (line_i >= start_line) {
+        lines[lines_found] = std::string(source_str, i - length, length);
+        lines_found++;
+      }
+      line_i++;
+      length = 0;
+    }
+    else {
+      length++;
+    }
+  }
+  if (line_i >= start_line && length != 0 && lines_found < line_limit) {
+    lines[lines_found] = std::string(source_str, limit - length, length);
+    lines_found++;
+  }
+}
+
+
+void Script::GetLineColumnFromPos(int64_t pos,
+                                  int64_t& line, int64_t& column, Error& err) {
+  line = 0;
+  column = 0;
+
+  HeapObject source = Source(err);
+  if (err.Fail()) return;
+
+  int64_t type = source.GetType(err);
+  if (err.Fail()) return;
+
+  // No source
+  if (type > v8()->types()->kFirstNonstringType) {
+    err = Error(true, "No source");
+    return;
   }
 
   String str(source);
@@ -373,20 +477,17 @@ std::string Script::GetLineColumnFromPos(int64_t pos, Error& err) {
   if (limit > pos)
     limit = pos;
 
-  int line = 1;
-  int column = 1;
   for (int64_t i = 0; i < limit; i++, column++) {
+    // \r\n should ski adding a line and column on \r
+    if (source_str[i] == '\r' && i < limit - 1 && source_str[i + 1] == '\n') {
+      i++;
+    }
     if (source_str[i] == '\n' || source_str[i] == '\r') {
       column = 0;
       line++;
     }
   }
-
-  snprintf(tmp, sizeof(tmp), ":%d:%d", static_cast<int>(line),
-      static_cast<int>(column));
-  return tmp;
 }
-
 
 bool Value::IsHoleOrUndefined(Error& err) {
   HeapObject obj(this);

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -24,6 +24,8 @@ class Error {
 
   inline bool Success() const { return !Fail(); }
   inline bool Fail() const { return failed_; }
+  
+  inline const char* GetMessage() { return msg_; }
 
  private:
   bool failed_;
@@ -131,7 +133,11 @@ class Script : public HeapObject {
   inline HeapObject Source(Error& err);
   inline HeapObject LineEnds(Error& err);
 
-  std::string GetLineColumnFromPos(int64_t pos, Error& err);
+  void GetLines(uint64_t start_line, std::string lines[],
+                          uint64_t line_limit, uint32_t &lines_found,
+                          Error& err);
+  void GetLineColumnFromPos(int64_t pos,
+                            int64_t& line, int64_t& column, Error& err);
 };
 
 class Code : public HeapObject {
@@ -365,9 +371,13 @@ class JSFrame : public Value {
   V8_VALUE_DEFAULT_METHODS(JSFrame, Value)
 
   inline int64_t LeaParamSlot(int slot, int count) const;
+  inline JSFunction GetFunction(Error& err);
   inline Value GetReceiver(int count, Error &err);
   inline Value GetParam(int slot, int count, Error &err);
-
+  
+  uint32_t GetSourceForDisplay(bool set_line, uint32_t line_start,
+                           uint32_t line_limit, std::string lines[],
+                           uint32_t& lines_found, Error& err);
   std::string Inspect(bool with_args, Error& err);
   std::string InspectArgs(JSFunction fn, Error& err);
 };


### PR DESCRIPTION
adds `v8 source list` when on a v8 stack frame

uses `-l $lineno` to match lldb, does not support giving memory pointer to the command yet.