### PR TITLE
improving colors of backtrace command

### DIFF
--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -65,8 +65,8 @@ bool BacktraceCmd::DoExecute(SBDebugger d, char** cmd,
     if (err.Fail()) continue;
 
     // V8 symbol
-    result.Printf(frame == selected_frame ? "  * frame #%u: 0x%016llx %s\n"
-                                          : "    frame #%u: 0x%016llx %s\n",
+    result.Printf(frame == selected_frame ? "\033[0;92m  * frame #%u:\033[0;90m 0x%016llx \033[0;32m%s\033[0m\n"
+                                          : "\033[0;92m    frame #%u:\033[0;90m 0x%016llx \033[0;32m%s\033[0m\n",
                   i, static_cast<unsigned long long int>(frame.GetPC()),
                   res.c_str());
   }


### PR DESCRIPTION
- using ansi escape codes to make JS trace blend better
- JS frame description in green to distinguish it from C/C++

<img width="846" alt="screen shot 2015-11-19 at 1 16 48 pm" src="https://cloud.githubusercontent.com/assets/192891/11276311/60b7b024-8ec0-11e5-8f0f-688fc24eb2b3.png">

If you'd like a different color for the description, please LMK.
I figured green is good for JS (github uses it too).