### PR TITLE
Enable Mac to build llnode against a locally compiled version of lldb.

### DIFF
--- a/llnode.gyp
+++ b/llnode.gyp
@@ -1,4 +1,10 @@
 {
+  "variables": {
+      # gyp does not appear to let you test for undefined variables, so define
+      # lldb_build_dir as empty so we can test it later.
+      "lldb_build_dir%": ""
+  },
+
   "targets": [{
     "target_name": "llnode",
     "type": "shared_library",
@@ -17,18 +23,31 @@
 
     "conditions": [
       [ "OS == 'mac'", {
-        "variables": {
-          "mac_shared_frameworks": "/Applications/Xcode.app/Contents/SharedFrameworks",
-        },
-        "xcode_settings": {
-          "OTHER_LDFLAGS": [
-            "-F<(mac_shared_frameworks)",
-            "-Wl,-rpath,<(mac_shared_frameworks)",
-            "-framework LLDB",
-          ],
-        },
-      }, {
+        "conditions": [
+          [ "lldb_build_dir == ''", {
+            "variables": {
+              "mac_shared_frameworks": "/Applications/Xcode.app/Contents/SharedFrameworks",
+            },
+            "xcode_settings": {
+              "OTHER_LDFLAGS": [
+                "-F<(mac_shared_frameworks)",
+                "-Wl,-rpath,<(mac_shared_frameworks)",
+                "-framework LLDB",
+              ],
+            },
+          },
+          # lldb_builddir != ""
+          {
+            "xcode_settings": {
+              "OTHER_LDFLAGS": [
+                "-Wl,-rpath,<(lldb_build_dir)/lib",
+                "-L<(lldb_build_dir)/lib",
+                "-l<(lldb_lib)",
+              ],
+            },
+          }],
+        ],
       }],
-    ],
-  }]
+    ]
+  }],
 }


### PR DESCRIPTION
This is for #11 - You've already done the change for Linux by removing the lib flag so I've updated the comment just to reference Mac.