### PR TITLE
Add support for listing all the JavaScript objects contained in a core dump

### DIFF
--- a/llnode.gyp
+++ b/llnode.gyp
@@ -19,6 +19,7 @@
       "src/llnode.cc",
       "src/llv8.cc",
       "src/llv8-constants.cc",
+      "src/llscan.cc",
     ],
 
     "conditions": [

--- a/scripts/otool2segments.py
+++ b/scripts/otool2segments.py
@@ -1,0 +1,43 @@
+'''
+Created on 7 Apr 2016
+
+@author: hhellyer
+'''
+import sys,os,subprocess
+
+OTOOL_COMMAND = "otool -l {0}"
+
+# Grab the details of the memory ranges in the process from otool.
+def main():
+    if( len(sys.argv) < 2 ):
+        print("Usage " + sys.argv[0] + " <core_file>")
+        sys.exit(1)
+    core_file = sys.argv[1]
+
+    readelf_proc = subprocess.Popen(OTOOL_COMMAND.format(core_file), shell=True, bufsize=1,
+          stdin=subprocess.PIPE, stdout=subprocess.PIPE, close_fds=True)
+    (readelf_stdin, readelf_stdout) = (readelf_proc.stdin, readelf_proc.stdout)
+    
+    reading_segment = False
+    vaddress = ""
+
+    for line in readelf_stdout:
+        line = line.strip()
+        if not line.startswith("vmaddr") and not reading_segment:
+            continue
+        elif line.startswith("vmaddr"):
+            # Might need to filer out segments that have a file offset of 0 (ie aren't in the core!)
+            reading_segment = True
+            (name, vaddress) = line.split()
+        elif line.startswith("vmsize") and reading_segment:
+            reading_segment = False
+            memsize = line.split()[1]
+            # Simple format "address size", both in hex
+            print("{0} {1}".format(vaddress, memsize))
+            vaddress = ""
+    
+	
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/otool2segments.py
+++ b/scripts/otool2segments.py
@@ -14,19 +14,21 @@ def main():
         sys.exit(1)
     core_file = sys.argv[1]
 
-    readelf_proc = subprocess.Popen(OTOOL_COMMAND.format(core_file), shell=True, bufsize=1,
-          stdin=subprocess.PIPE, stdout=subprocess.PIPE, close_fds=True)
-    (readelf_stdin, readelf_stdout) = (readelf_proc.stdin, readelf_proc.stdout)
-    
+    otool_proc = subprocess.Popen(
+        OTOOL_COMMAND.format(core_file), shell=True, bufsize=1,
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, close_fds=True)
+    (otool_stdin, otool_stdout) = (otool_proc.stdin, otool_proc.stdout)
+
     reading_segment = False
     vaddress = ""
 
-    for line in readelf_stdout:
+    for line in otool_stdout:
         line = line.strip()
         if not line.startswith("vmaddr") and not reading_segment:
             continue
         elif line.startswith("vmaddr"):
-            # Might need to filer out segments that have a file offset of 0 (ie aren't in the core!)
+            # Might need to filer out segments that have a file offset of 0
+            # (ie segments that aren't in the core!)
             reading_segment = True
             (name, vaddress) = line.split()
         elif line.startswith("vmsize") and reading_segment:
@@ -35,9 +37,6 @@ def main():
             # Simple format "address size", both in hex
             print("{0} {1}".format(vaddress, memsize))
             vaddress = ""
-    
-	
-
 
 if __name__ == '__main__':
     main()

--- a/scripts/readelf2segments.py
+++ b/scripts/readelf2segments.py
@@ -14,10 +14,11 @@ def main():
         sys.exit(1)
     core_file = sys.argv[1]
 
-    readelf_proc = subprocess.Popen(READELF_COMMAND.format(core_file), shell=True, bufsize=1,
-          stdin=subprocess.PIPE, stdout=subprocess.PIPE, close_fds=True)
+    readelf_proc = subprocess.Popen(
+        READELF_COMMAND.format(core_file), shell=True, bufsize=1,
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, close_fds=True)
     (readelf_stdin, readelf_stdout) = (readelf_proc.stdin, readelf_proc.stdout)
-    
+
     reading_segment = False
     vaddress = ""
 
@@ -26,7 +27,8 @@ def main():
         if not line.startswith("LOAD") and not reading_segment:
             continue
         elif line.startswith("LOAD"):
-            # Might need to filer out segments that have a file offset of 0 (ie aren't in the core!)
+            # Might need to filer out segments that have a file offset of 0
+            # (ie segments that aren't in the core!)
             reading_segment = True
             (type, offset, vaddress, paddr) = line.split()
         elif reading_segment:
@@ -35,9 +37,6 @@ def main():
             # Simple format "address size", both in hex
             print("{0} {1}".format(vaddress, memsize))
             vaddress = ""
-    
-        
-
 
 if __name__ == '__main__':
     main()

--- a/scripts/readelf2segments.py
+++ b/scripts/readelf2segments.py
@@ -1,0 +1,43 @@
+'''
+Created on 7 Apr 2016
+
+@author: hhellyer
+'''
+import sys,os,subprocess
+
+READELF_COMMAND = "readelf --segments {0}"
+
+# Grab the details of the memory ranges in the process from readelf.
+def main():
+    if( len(sys.argv) < 2 ):
+        print("Usage " + sys.argv[0] + " <core_file>")
+        sys.exit(1)
+    core_file = sys.argv[1]
+
+    readelf_proc = subprocess.Popen(READELF_COMMAND.format(core_file), shell=True, bufsize=1,
+          stdin=subprocess.PIPE, stdout=subprocess.PIPE, close_fds=True)
+    (readelf_stdin, readelf_stdout) = (readelf_proc.stdin, readelf_proc.stdout)
+    
+    reading_segment = False
+    vaddress = ""
+
+    for line in readelf_stdout:
+        line = line.strip()
+        if not line.startswith("LOAD") and not reading_segment:
+            continue
+        elif line.startswith("LOAD"):
+            # Might need to filer out segments that have a file offset of 0 (ie aren't in the core!)
+            reading_segment = True
+            (type, offset, vaddress, paddr) = line.split()
+        elif reading_segment:
+            reading_segment = False
+            memsize = line.split()[1]
+            # Simple format "address size", both in hex
+            print("{0} {1}".format(vaddress, memsize))
+            vaddress = ""
+    
+        
+
+
+if __name__ == '__main__':
+    main()

--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -7,6 +7,7 @@
 
 #include "src/llnode.h"
 #include "src/llv8.h"
+#include "src/llscan.h"
 
 namespace llnode {
 
@@ -281,6 +282,21 @@ bool PluginInitialize(SBDebugger d) {
                     "Syntax: v8 source list\n");
   interpreter.AddCommand("jssource", new llnode::ListCmd(),
                          "Alias for `v8 source list`");
+
+  v8.AddCommand("listobjects", new llnode::ListObjectsCmd(),
+      "List all object types and instance counts grouped by map and sorted by instance count.\n"
+      "Requires RANGESFILE to be set to a file containing memory ranges for the core file being debugged.");
+
+  interpreter.AddCommand("listobjects", new llnode::ListObjectsCmd(),
+       "Alias for `v8 listobjects`");
+
+  v8.AddCommand("listinstances", new llnode::ListInstancesCmd(),
+       "List all objects which share the specified map.\n"
+       "Accepts the same options as `v8 inspect`");
+
+  interpreter.AddCommand("listinstances", new llnode::ListInstancesCmd(),
+          "List all objects which share the specified map.\n");
+
 
   return true;
 }

--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -283,20 +283,20 @@ bool PluginInitialize(SBDebugger d) {
   interpreter.AddCommand("jssource", new llnode::ListCmd(),
                          "Alias for `v8 source list`");
 
-  v8.AddCommand("listobjects", new llnode::ListObjectsCmd(),
+  v8.AddCommand("findjsobjects", new llnode::FindObjectsCmd(),
                 "List all object types and instance counts grouped by map and "
                 "sorted by instance count.\n"
                 "Requires RANGESFILE to be set to a file containing memory "
                 "ranges for the core file being debugged.");
 
-  interpreter.AddCommand("listobjects", new llnode::ListObjectsCmd(),
-                         "Alias for `v8 listobjects`");
+  interpreter.AddCommand("findjsobjects", new llnode::FindObjectsCmd(),
+                         "Alias for `v8 findjsobjects`");
 
-  v8.AddCommand("listinstances", new llnode::ListInstancesCmd(),
+  v8.AddCommand("findjsinstances", new llnode::FindInstancesCmd(),
                 "List all objects which share the specified map.\n"
                 "Accepts the same options as `v8 inspect`");
 
-  interpreter.AddCommand("listinstances", new llnode::ListInstancesCmd(),
+  interpreter.AddCommand("findjsinstances", new llnode::FindInstancesCmd(),
                          "List all objects which share the specified map.\n");
 
 

--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -1,13 +1,13 @@
 #include <errno.h>
+#include <getopt.h>
 #include <stdlib.h>
 #include <string.h>
-#include <getopt.h>
 
 #include <lldb/API/SBExpressionOptions.h>
 
 #include "src/llnode.h"
-#include "src/llv8.h"
 #include "src/llscan.h"
+#include "src/llv8.h"
 
 namespace llnode {
 
@@ -284,18 +284,20 @@ bool PluginInitialize(SBDebugger d) {
                          "Alias for `v8 source list`");
 
   v8.AddCommand("listobjects", new llnode::ListObjectsCmd(),
-      "List all object types and instance counts grouped by map and sorted by instance count.\n"
-      "Requires RANGESFILE to be set to a file containing memory ranges for the core file being debugged.");
+                "List all object types and instance counts grouped by map and "
+                "sorted by instance count.\n"
+                "Requires RANGESFILE to be set to a file containing memory "
+                "ranges for the core file being debugged.");
 
   interpreter.AddCommand("listobjects", new llnode::ListObjectsCmd(),
-       "Alias for `v8 listobjects`");
+                         "Alias for `v8 listobjects`");
 
   v8.AddCommand("listinstances", new llnode::ListInstancesCmd(),
-       "List all objects which share the specified map.\n"
-       "Accepts the same options as `v8 inspect`");
+                "List all objects which share the specified map.\n"
+                "Accepts the same options as `v8 inspect`");
 
   interpreter.AddCommand("listinstances", new llnode::ListInstancesCmd(),
-          "List all objects which share the specified map.\n");
+                         "List all objects which share the specified map.\n");
 
 
   return true;

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -1,7 +1,7 @@
 #include <errno.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
-#include <inttypes.h>
 
 #include <algorithm>
 #include <fstream>
@@ -10,108 +10,105 @@
 #include <lldb/API/SBExpressionOptions.h>
 
 #include "src/llnode.h"
-#include "src/llv8.h"
-#include "src/llv8-inl.h"
 #include "src/llscan.h"
+#include "src/llv8-inl.h"
+#include "src/llv8.h"
 
 namespace llnode {
 
 // Defined in llnode.cc
 extern v8::LLV8 llv8;
 
-struct MemoryRange {
-    uint64_t start;
-    uint64_t length;
-    MemoryRange* next;
-};
-
-static MemoryRange* ranges = nullptr;
-
-std::map<uint64_t, TypeRecord*>* mapstoinstances = NULL;
+LLScan llscan;
 
 using namespace lldb;
 
+
 bool ListObjectsCmd::DoExecute(SBDebugger d, char** cmd,
-        SBCommandReturnObject& result) {
+                               SBCommandReturnObject& result) {
+  SBTarget target = d.GetSelectedTarget();
+  if (!target.IsValid()) {
+    result.SetError("No valid process, please start something\n");
+    return false;
+  }
 
-    SBTarget target = d.GetSelectedTarget();
-    if (!target.IsValid()) {
-        result.SetError("No valid process, please start something\n");
-        return false;
-    }
+  /* Ensure we have a map of objects. */
+  if (!llscan.ScanHeapForObjects(target, result)) {
+    return false;
+  }
 
-    /* Ensure we have a map of objects. */
-    if (!ScanHeapForObjects(&target, result)) {
-        return false;
-    }
+  /* Create a vector to hold the entries sorted by instance count
+   * TODO(hhellyer) - Make sort type an option (by count, size or name)
+   */
+  std::vector<TypeRecord*> sorted_by_count;
+  std::map<uint64_t, TypeRecord*>::iterator end =
+      llscan.GetMapsToInstances().end();
+  for (std::map<uint64_t, TypeRecord*>::iterator it =
+           llscan.GetMapsToInstances().begin();
+       it != end; ++it) {
+    sorted_by_count.push_back(it->second);
+  }
 
-    /* Create a vector to hold the entries sorted by instance count
-     * TODO - Make sort type an option (by count, size or name)
-     */
-    std::vector<TypeRecord*> sorted_by_count = std::vector<TypeRecord*>();
-    for (std::map<uint64_t, TypeRecord*>::iterator it = mapstoinstances->begin();
-            it != mapstoinstances->end(); ++it) {
-        sorted_by_count.push_back(it->second);
-    }
-
-    std::sort(sorted_by_count.begin(), sorted_by_count.end(),
+  std::sort(sorted_by_count.begin(), sorted_by_count.end(),
             TypeRecord::compareInstanceCounts);
 
-    uint64_t total_objects = 0;
+  uint64_t total_objects = 0;
 
-    result.Printf( "Map                Instances  Total Size Name\n" );
-    result.Printf( "------------------ ---------- ---------- ----\n" );
+  result.Printf("Map                Instances  Total Size Name\n");
+  result.Printf("------------------ ---------- ---------- ----\n");
 
-    for (std::vector<TypeRecord*>::iterator it = sorted_by_count.begin();
-            it != sorted_by_count.end(); ++it) {
-        TypeRecord* t = *it;
-        result.Printf("0x%016" PRIx64 " %10" PRId64 " %10" PRId64 " %s\n",
-                t->map, t->instance_count, t->total_instance_size,
-                t->type_name->c_str());
-        total_objects += t->instance_count;
-    }
+  for (std::vector<TypeRecord*>::iterator it = sorted_by_count.begin();
+       it != sorted_by_count.end(); ++it) {
+    TypeRecord* t = *it;
+    result.Printf("0x%016" PRIx64 " %10" PRId64 " %10" PRId64 " %s\n", t->map,
+                  t->instance_count, t->total_instance_size,
+                  t->type_name->c_str());
+    total_objects += t->instance_count;
+  }
 
-    return true;
+  return true;
 }
+
 
 /* Utility function to generate short type names for objects.
  * Based on the inspection code in llv8.cc
- * TODO Merge back in to llv8.cc?
+ * TODO(indutny) - Should this merge back in to llv8.cc?
  */
-std::string GetTypeName( llnode::v8::HeapObject *heap_object, v8::Value::InspectOptions *options, v8::Error err ) {
-  int64_t type = heap_object->GetType(err);
-  v8::LLV8 *v8 = heap_object->v8();
-  if (type == v8->types()->kGlobalObjectType) return heap_object->Inspect(options, err);
-  if (type == v8->types()->kCodeType) return heap_object->Inspect(options, err);
+std::string GetTypeName(v8::HeapObject& heap_object,
+                        v8::Value::InspectOptions& options, v8::Error err) {
+  int64_t type = heap_object.GetType(err);
+  v8::LLV8* v8 = heap_object.v8();
+  if (type == v8->types()->kGlobalObjectType)
+    return heap_object.Inspect(&options, err);
+  if (type == v8->types()->kCodeType) return heap_object.Inspect(&options, err);
   if (type == v8->types()->kMapType) {
-    return heap_object->Inspect(options, err);
+    return heap_object.Inspect(&options, err);
   }
 
   if (type == v8->types()->kJSObjectType) {
+    v8::HeapObject map_obj = heap_object.GetMap(err);
+    if (err.Fail()) {
+      return std::string();
+    }
 
-      llnode::v8::HeapObject map_obj = heap_object->GetMap(err);
-      if (err.Fail()) {
-          return std::string();
-      }
+    v8::Map map(map_obj);
+    v8::HeapObject constructor_obj = map.Constructor(err);
+    if (err.Fail()) {
+      return std::string();
+    }
 
-      llnode::v8::Map map(map_obj);
-      llnode::v8::HeapObject constructor_obj = map.Constructor(err);
-      if (err.Fail()) {
-          return std::string();
-      }
+    int64_t constructor_type = constructor_obj.GetType(err);
+    if (err.Fail()) {
+      return std::string();
+    }
 
-      int64_t constructor_type = constructor_obj.GetType(err);
-      if (err.Fail()) {
-          return std::string();
-      }
+    if (constructor_type != v8->types()->kJSFunctionType) {
+      return "<Object: no constructor>";
+    }
 
-      if (constructor_type != v8->types()->kJSFunctionType) {
-        return "<Object: no constructor>";
-      }
+    v8::JSFunction constructor(constructor_obj);
 
-      llnode::v8::JSFunction constructor(constructor_obj);
-
-      return constructor.Name(err);
+    return constructor.Name(err);
   }
 
   if (type == v8->types()->kHeapNumberType) {
@@ -159,312 +156,342 @@ std::string GetTypeName( llnode::v8::HeapObject *heap_object, v8::Value::Inspect
   return unknown += std::to_string(type);
 }
 
+
 bool ListInstancesCmd::DoExecute(SBDebugger d, char** cmd,
-        SBCommandReturnObject& result) {
-    SBTarget target = d.GetSelectedTarget();
-    if (!target.IsValid()) {
-        result.SetError("No valid process, please start something\n");
-        return false;
+                                 SBCommandReturnObject& result) {
+  SBTarget target = d.GetSelectedTarget();
+  if (!target.IsValid()) {
+    result.SetError("No valid process, please start something\n");
+    return false;
+  }
+
+  v8::Value::InspectOptions inspect_options;
+
+  inspect_options.detailed = detailed_;
+
+  char** start = ParseInspectOptions(cmd, &inspect_options);
+
+  std::string full_cmd;
+  for (; start != nullptr && *start != nullptr; start++) full_cmd += *start;
+
+  SBExpressionOptions options;
+  SBValue value = target.EvaluateExpression(full_cmd.c_str(), options);
+  if (value.GetError().Fail()) {
+    SBStream desc;
+    if (!value.GetError().GetDescription(desc)) return false;
+    result.SetError(desc.GetData());
+    return false;
+  }
+
+  // Load V8 constants from postmortem data
+  llv8.Load(target);
+
+  v8::Value v8_mapaddr(&llv8, value.GetValueAsSigned());
+  v8::Error err;
+
+  if (err.Fail()) {
+    result.SetError("Failed to evaluate expression");
+    return false;
+  }
+
+  uint64_t mapaddr = value.GetValueAsUnsigned();
+  std::map<uint64_t, TypeRecord*>::iterator instance_it =
+      llscan.GetMapsToInstances().find(mapaddr);
+  if (instance_it != llscan.GetMapsToInstances().end()) {
+    TypeRecord* t = instance_it->second;
+    for (std::set<uint64_t>::iterator it = t->instances->begin();
+         it != t->instances->end(); ++it) {
+      v8::Error err;
+      v8::Value v8_value(&llv8, *it);
+      std::string res = v8_value.Inspect(&inspect_options, err);
+      result.Printf("%s\n", res.c_str());
     }
 
-    v8::Value::InspectOptions inspect_options;
+  } else {
+    result.Printf("No objects found with map %" PRIx64 "\n", mapaddr);
+  }
 
-    inspect_options.detailed = detailed_;
-
-    char** start = ParseInspectOptions(cmd, &inspect_options);
-
-    std::string full_cmd;
-    for (; start != nullptr && *start != nullptr; start++) full_cmd += *start;
-
-    SBExpressionOptions options;
-    SBValue value = target.EvaluateExpression(full_cmd.c_str(), options);
-    if (value.GetError().Fail()) {
-        SBStream desc;
-        if (!value.GetError().GetDescription(desc)) return false;
-        result.SetError(desc.GetData());
-        return false;
-    }
-
-    // Load V8 constants from postmortem data
-    llv8.Load(target);
-
-    v8::Value v8_mapaddr(&llv8, value.GetValueAsSigned());
-    v8::Error err;
-
-    if (err.Fail()) {
-        result.SetError("Failed to evaluate expression");
-        return false;
-    }
-
-    uint64_t mapaddr = value.GetValueAsUnsigned();
-    std::map<uint64_t, TypeRecord*>::iterator instance_it =
-            mapstoinstances->find(mapaddr);
-    if (instance_it != mapstoinstances->end()) {
-        TypeRecord* t = instance_it->second;
-        for (std::set<uint64_t>::iterator it = t->instances->begin();
-                it != t->instances->end(); ++it) {
-            v8::Error err;
-            v8::Value v8_value(&llv8, *it);
-            std::string res = v8_value.Inspect(&inspect_options, err);
-            result.Printf("%s\n", res.c_str());
-        }
-
-    } else {
-        result.Printf("No objects found with map %" PRIx64 "\n", mapaddr);
-    }
-
-    return true;
-
+  return true;
 }
 
-FindJSObjectsVisitor::FindJSObjectsVisitor(SBTarget* target,
-        SBCommandReturnObject* result) {
-    _target = target;
-    _result = result;
-    // Load V8 constants from postmortem data
-    llv8.Load(*target);
-    _address_byte_size = _target->GetProcess().GetAddressByteSize();
-    _found_count = 0;
-    mapstoinstances = new std::map<uint64_t, TypeRecord*>();
+
+FindJSObjectsVisitor::FindJSObjectsVisitor(
+    SBTarget& target, std::map<uint64_t, TypeRecord*>& mapstoinstances)
+    : target_(target), mapstoinstances_(mapstoinstances) {
+  found_count_ = 0;
+  address_byte_size_ = target_.GetProcess().GetAddressByteSize();
+  // Load V8 constants from postmortem data
+  llv8.Load(target);
 }
+
 
 /* Visit every address, a bit brute force but it works. */
 uint64_t FindJSObjectsVisitor::Visit(uint64_t location, uint64_t available) {
+  lldb::SBError error;
 
-    lldb::SBError error;
+  // Test if the map points to a real map.
+  // Try to create an object out of it.
 
-    // Test if the map points to a real map.
-    // Try to create an object out of it.
+  uint64_t word = target_.GetProcess().ReadUnsignedFromMemory(
+      location, target_.GetProcess().GetAddressByteSize(), error);
 
-    uint64_t word = _target->GetProcess().ReadUnsignedFromMemory(location,
-            _target->GetProcess().GetAddressByteSize(), error);
+  v8::Value v8_value(&llv8, word);
 
-    v8::Value v8_value(&llv8, word);
+  v8::Error err;
+  // Test if this is SMI
+  // Skip inspecting things that look like Smi's, they aren't objects.
+  v8::Smi smi(v8_value);
+  if (smi.Check()) {
+    return address_byte_size_;
+  }
 
-    v8::Error err;
-    // Test if this is SMI
-    // Skip inspecting things that look like Smi's, they aren't objects.
-    llnode::v8::Smi smi(v8_value);
-    if (smi.Check()) {
-        return _address_byte_size;
-    }
+  v8::HeapObject heap_object(v8_value);
+  if (!heap_object.Check()) {
+    return address_byte_size_;
+  }
+  if (heap_object.IsHoleOrUndefined(err)) {
+    return address_byte_size_;
+  }
+  if (err.Fail()) {
+    return address_byte_size_;
+  }
 
-    llnode::v8::HeapObject heap_object(v8_value);
-    if (!heap_object.Check()) {
-        return _address_byte_size;
-    }
-    if (heap_object.IsHoleOrUndefined(err)) {
-        return _address_byte_size;
-    }
-    if (err.Fail()) {
-        return _address_byte_size;
-    }
+  v8::HeapObject map_object = heap_object.GetMap(err);
+  if (err.Fail() || !map_object.Check()) {
+    return address_byte_size_;
+  }
 
-    llnode::v8::HeapObject map_object = heap_object.GetMap(err);
-    if (err.Fail() || !map_object.Check()) {
-        return _address_byte_size;
-    }
+  if (!IsAHistogramType(heap_object, err)) {
+    return address_byte_size_;
+  }
 
-    if( !IsAHistogramType(&heap_object, err) ) {
-        return _address_byte_size;
-    }
+  if (err.Fail()) {
+    return address_byte_size_;
+  }
 
-    if (err.Fail()) {
-        return _address_byte_size;
-    }
+  v8::Map map(map_object);
 
-    llnode::v8::Map map(map_object);
+  v8::Value::InspectOptions inspect_options;
+  inspect_options.detailed = false;
+  inspect_options.print_map = false;
+  inspect_options.string_length = 0;
 
-    v8::Value::InspectOptions inspect_options;
-    inspect_options.detailed = false;
-    inspect_options.print_map = false;
-    inspect_options.string_length = 0;
+  /* No entry in the map, create a new one. */
+  if (mapstoinstances_.count(map_object.raw()) == 0) {
+    TypeRecord* t = new TypeRecord();
+    t->map = map_object.raw();
+    t->instance_count++;
+    // TODO(indutny) - Is this correct or is there a better way to find the size
+    // of one instance of an object?
+    t->total_instance_size = map.InstanceSize(err);
 
-    /* No entry in the map, create a new one. */
-    if (mapstoinstances->count(map_object.raw()) == 0) {
-        TypeRecord* t = new TypeRecord();
-        t->map = map_object.raw();
-        t->instance_count++;
-        // TODO - Do I need a better way to find the size of one instance of an object?
-        t->total_instance_size = map.InstanceSize(err);
+    t->type_name =
+        new std::string(GetTypeName(heap_object, inspect_options, err));
 
-        t->type_name = new std::string(GetTypeName(&heap_object, &inspect_options, err));
-
-        mapstoinstances->insert(
-                std::pair<uint64_t, TypeRecord*>(map_object.raw(), t));
-        t->instances = new std::set<uint64_t>();
-    } else {
-        /* Update an existing instance, if we haven't seen this one before. */
-        TypeRecord* t = mapstoinstances->at(map_object.raw());
-        /* Determine if this is a new instance.
-         * (We are scanning pointers to objects, we may have seen this location before.)
-         */
-        if (t->instances->count(word) == 0) {
-            t->instances->insert(word);
-            t->instance_count++;
-            // TODO - Do I need a better way to find the size of one instance of an object?
-            t->total_instance_size += map.InstanceSize(err);
-        }
-    }
-
-    if (err.Fail()) {
-        return _address_byte_size;
-    }
-
-    _found_count++;
-
-    /* Just advance one word.
-     * (Should advance by object size, assuming objects can't overlap!)
+    mapstoinstances_.insert(
+        std::pair<uint64_t, TypeRecord*>(map_object.raw(), t));
+    t->instances = new std::set<uint64_t>();
+  } else {
+    /* Update an existing instance, if we haven't seen this one before. */
+    TypeRecord* t = mapstoinstances_.at(map_object.raw());
+    /* Determine if this is a new instance.
+     * (We are scanning pointers to objects, we may have seen this location
+     * before.)
      */
-    return _address_byte_size;
+    if (t->instances->count(word) == 0) {
+      t->instances->insert(word);
+      t->instance_count++;
+      // TODO(indutny) - Is this correct or is there a better way to find the
+      // size of one instance of an object?
+      t->total_instance_size += map.InstanceSize(err);
+    }
+  }
+
+  if (err.Fail()) {
+    return address_byte_size_;
+  }
+
+  found_count_++;
+
+  /* Just advance one word.
+   * (Should advance by object size, assuming objects can't overlap!)
+   */
+  return address_byte_size_;
 }
 
-bool FindJSObjectsVisitor::IsAHistogramType( llnode::v8::HeapObject *heap_object, v8::Error err ) {
-    int64_t type = heap_object->GetType(err);
-    v8::LLV8 *v8 = heap_object->v8();
-    if (type == v8->types()->kJSObjectType) return true;
-    if (type == v8->types()->kJSArrayType) return true;
-    if (type == v8->types()->kJSTypedArrayType) return true;
-    return false;
+
+bool FindJSObjectsVisitor::IsAHistogramType(v8::HeapObject& heap_object,
+                                            v8::Error err) {
+  int64_t type = heap_object.GetType(err);
+  v8::LLV8* v8 = heap_object.v8();
+  if (type == v8->types()->kJSObjectType) return true;
+  if (type == v8->types()->kJSArrayType) return true;
+  if (type == v8->types()->kJSTypedArrayType) return true;
+  return false;
 }
 
-bool ScanHeapForObjects(lldb::SBTarget* target,
-        lldb::SBCommandReturnObject result) {
 
-    /* TODO - Check whether we have the SBGetMemoryRegionInfoList API available and implemented.
-     * (It may be available but not supported on this platform.)
-     * If it is then check the last scan is still valid - the process hasn't moved and we
-     * haven't changed target.
+bool LLScan::ScanHeapForObjects(lldb::SBTarget target,
+                                lldb::SBCommandReturnObject result) {
+  /* TODO(hhellyer) - Check whether we have the SBGetMemoryRegionInfoList API
+   * available
+   * and implemented.
+   * (It may be available but not supported on this platform.)
+   * If it is then check the last scan is still valid - the process hasn't moved
+   * and we haven't changed target.
+   */
+
+  // Reload process anyway
+  process_ = target.GetProcess();
+
+  // Need to reload memory ranges (though this does assume the user has also
+  // updated
+  // RANGESFILE with data for the new dump or things won't match up).
+  if (target_ != target) {
+    MemoryRange* head = ranges_;
+    while (head != nullptr) {
+      MemoryRange* range = head;
+      head = head->next;
+      delete range;
+    }
+    ranges_ = nullptr;
+  }
+
+  /* Fall back to environment variable containing pre-parsed list of memory
+   * ranges. */
+  if (nullptr == ranges_) {
+    const char* segmentsfilename = getenv("RANGESFILE");
+
+    //
+    if (segmentsfilename == nullptr) {
+      //		  result.Printf("No memory ranges file. Plugin commands
+      // that need to scan addressable memory will fail.\n");
+      result.SetError(
+          "No memory range information available for this process. Cannot scan "
+          "for objects.\n");
+      return false;
+    }
+
+    if (!GenerateMemoryRanges(target, segmentsfilename)) {
+      result.SetError(
+          "No memory range information available for this process. Cannot scan "
+          "for objects.\n");
+      return false;
+    }
+  }
+
+  /* If we've reached here we have access to information about the valid memory
+   * ranges in the
+   * process and can scan for objects.
+   */
+
+  /* Populate the map of objects. */
+  if (mapstoinstances_.empty()) {
+    FindJSObjectsVisitor v(target, GetMapsToInstances());
+
+    ScanMemoryRanges(v);
+
+    result.Printf("Did search of memory - found %d pointers)\n",
+                  v.FoundCount());
+
+  } else {
+    result.Printf("Re-using cached map\n");
+  }
+
+  return true;
+}
+
+
+void LLScan::ScanMemoryRanges(FindJSObjectsVisitor& v) {
+  MemoryRange* head = ranges_;
+
+  bool done = false;
+
+  while (head != nullptr && !done) {
+    uint64_t address = head->start;
+    uint64_t len = head->length;
+    head = head->next;
+
+    /* Brute force search - query every address - but allow the visitor code to
+     * say
+     * how far to move on so we don't read every byte.
      */
-
-    /* Fall back to environment variable containing pre-parsed list of memory ranges. */
-    if (nullptr == ranges) {
-
-        const char* segmentsfilename = getenv("RANGESFILE");
-
-        //
-        if (segmentsfilename == nullptr) {
-            //		  result.Printf("No memory ranges file. Plugin commands that need to scan addressable memory will fail.\n");
-            result.SetError(
-                    "No memory range information available for this process. Cannot scan for objects.\n");
-            return false;
-        }
-
-        if (!GenerateMemoryRanges(target, segmentsfilename)) {
-            result.SetError(
-                    "No memory range information available for this process. Cannot scan for objects.\n");
-            return false;
-        }
+    for (auto searchAddress = address; searchAddress < address + len;) {
+      //		  result.Printf("Checking for needle at: 0x%" PRIx64
+      //"\n", searchAddress);
+      //			  printf("Visiting address 0x%" PRIx64 "\n",
+      // searchAddress);
+      uint32_t increment =
+          v.Visit(searchAddress, (address + len) - searchAddress);
+      if (increment == 0) {
+        done = true;
+        break;
+      }
+      searchAddress += increment;
     }
-
-    /* If we've reached here we have access to information about the valid memory ranges in the
-     * process and can scan for objects.
-     */
-
-    /* Populate the map of objects. */
-    if (mapstoinstances == NULL) {
-
-        FindJSObjectsVisitor v(target, &result);
-
-        ScanMemoryRanges(v);
-
-        result.Printf("Did search of memory - found %d pointers)\n",
-                v.FoundCount());
-
-    } else {
-        result.Printf("Re-using cached map\n");
-    }
-
-    return true;
+  }
 }
 
-void ScanMemoryRanges(MemoryVisitor &v) {
-
-    MemoryRange *head = ranges;
-
-    bool done = false;
-
-    while (head != nullptr && !done) {
-        uint64_t address = head->start;
-        uint64_t len = head->length;
-        head = head->next;
-
-        /* Brute force search - query every address - but allow the visitor code to say
-         * how far to move on so we don't read every byte.
-         */
-        for (auto searchAddress = address; searchAddress < address + len;) {
-            //		  result.Printf("Checking for needle at: 0x%" PRIx64 "\n", searchAddress);
-            //			  printf("Visiting address 0x%" PRIx64 "\n", searchAddress);
-            uint32_t increment = v.Visit(searchAddress,
-                    (address + len) - searchAddress);
-            if (increment == 0) {
-                done = true;
-                break;
-            }
-            searchAddress += increment;
-        }
-    }
-}
 
 /* Read a file of memory ranges parsed from the core dump.
  * This is a work around for the lack of an API to get the memory ranges
  * within lldb.
- * There are scripts for generating this file on mac and linux stored as a snippet on github:
+ * There are scripts for generating this file on mac and linux stored as a
+ * snippet on github:
  * https://gist.github.com/hhellyer/6d79009e142d6eef696525afe1ecea43
- * export the name or full path to the ranges file in the RANGESFILE env var before starting
+ * export the name or full path to the ranges file in the RANGESFILE env var
+ * before starting
  * lldb and loading the llnode plugin.
  */
-bool GenerateMemoryRanges(lldb::SBTarget* target,
-        const char* segmentsfilename) {
+bool LLScan::GenerateMemoryRanges(lldb::SBTarget target,
+                                  const char* segmentsfilename) {
+  std::ifstream input(segmentsfilename);
 
-    std::ifstream input(segmentsfilename);
+  if (!input.is_open()) {
+    return false;
+  }
 
-    if (!input.is_open()) {
-        return false;
-    }
+  uint64_t address = 0, len = 0;
 
-    uint64_t address = 0, len = 0;
+  MemoryRange** tailptr = &ranges_;
 
-    llnode::MemoryRange **tailptr = &llnode::ranges;
+  lldb::addr_t address_byte_size = target.GetProcess().GetAddressByteSize();
 
-    lldb::addr_t address_byte_size = target->GetProcess().GetAddressByteSize();
+  while (input >> std::hex >> address >> std::hex >> len) {
+    /* Check if the range is accessible.
+     * The structure of a core file means if you check the start and the end of
+     * a range then the
+     * middle will be there, ranges are contiguous in the file, but cores often
+     * get truncated due
+     * to file size limits so ranges can be missing or truncated. Sometimes
+     * shared memory segments
+     * are omitted so it's also possible an entire section could be missing from
+     * the middle.
+     */
+    lldb::SBError error;
+    target.GetProcess().ReadPointerFromMemory(address, error);
+    if (error.Success()) {
+      target.GetProcess().ReadPointerFromMemory(
+          (address + len) - address_byte_size, error);
 
-    while (input >> std::hex >> address >> std::hex >> len) {
-
-        /* Check if the range is accessible.
-         * The structure of a core file means if you check the start and the end of a range then the
-         * middle will be there, ranges are contiguous in the file, but cores often get truncated due
-         * to file size limits so ranges can be missing or truncated. Sometimes shared memory segments
-         * are omitted so it's also possible an entire section could be missing from the middle.
-         */
-        lldb::SBError error;
-        target->GetProcess().ReadPointerFromMemory(address, error);
-        if (error.Success()) {
-            target->GetProcess().ReadPointerFromMemory(
-                    (address + len) - address_byte_size, error);
-
-            if (error.Success()) {
-                llnode::MemoryRange* newRange = new llnode::MemoryRange();
-                if (nullptr == newRange) {
-                    return false;
-                }
-                newRange->start = address;
-                newRange->length = len;
-                newRange->next = nullptr;
-                (*tailptr) = newRange;
-                tailptr = &(newRange->next);
-
-            } else {
-                /* Could not access last word, skip. */
-            }
-        } else {
-            /* Could not access first word, skip. */
+      if (error.Success()) {
+        MemoryRange* newRange = new MemoryRange();
+        if (nullptr == newRange) {
+          return false;
         }
+        newRange->start = address;
+        newRange->length = len;
+        newRange->next = nullptr;
+        (*tailptr) = newRange;
+        tailptr = &(newRange->next);
 
+      } else {
+        /* Could not access last word, skip. */
+      }
+    } else {
+      /* Could not access first word, skip. */
     }
-    return true;
-
+  }
+  return true;
 }
-
 }
-

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -221,7 +221,7 @@ bool FindJSObjectsVisitor::IsAHistogramType(v8::HeapObject& heap_object,
 
 
 bool LLScan::ScanHeapForObjects(lldb::SBTarget target,
-                                lldb::SBCommandReturnObject result) {
+                                lldb::SBCommandReturnObject &result) {
   /* TODO(hhellyer) - Check whether we have the SBGetMemoryRegionInfoList API
    * available
    * and implemented.
@@ -279,12 +279,6 @@ bool LLScan::ScanHeapForObjects(lldb::SBTarget target,
     FindJSObjectsVisitor v(target, GetMapsToInstances());
 
     ScanMemoryRanges(v);
-
-    result.Printf("Did search of memory - found %d pointers)\n",
-                  v.FoundCount());
-
-  } else {
-    result.Printf("Re-using cached map\n");
   }
 
   return true;

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -1,0 +1,470 @@
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+
+#include <algorithm>
+#include <fstream>
+#include <vector>
+
+#include <lldb/API/SBExpressionOptions.h>
+
+#include "src/llnode.h"
+#include "src/llv8.h"
+#include "src/llv8-inl.h"
+#include "src/llscan.h"
+
+namespace llnode {
+
+// Defined in llnode.cc
+extern v8::LLV8 llv8;
+
+struct MemoryRange {
+    uint64_t start;
+    uint64_t length;
+    MemoryRange* next;
+};
+
+static MemoryRange* ranges = nullptr;
+
+std::map<uint64_t, TypeRecord*>* mapstoinstances = NULL;
+
+using namespace lldb;
+
+bool ListObjectsCmd::DoExecute(SBDebugger d, char** cmd,
+        SBCommandReturnObject& result) {
+
+    SBTarget target = d.GetSelectedTarget();
+    if (!target.IsValid()) {
+        result.SetError("No valid process, please start something\n");
+        return false;
+    }
+
+    /* Ensure we have a map of objects. */
+    if (!ScanHeapForObjects(&target, result)) {
+        return false;
+    }
+
+    /* Create a vector to hold the entries sorted by instance count
+     * TODO - Make sort type an option (by count, size or name)
+     */
+    std::vector<TypeRecord*> sorted_by_count = std::vector<TypeRecord*>();
+    for (std::map<uint64_t, TypeRecord*>::iterator it = mapstoinstances->begin();
+            it != mapstoinstances->end(); ++it) {
+        sorted_by_count.push_back(it->second);
+    }
+
+    std::sort(sorted_by_count.begin(), sorted_by_count.end(),
+            TypeRecord::compareInstanceCounts);
+
+    uint64_t total_objects = 0;
+
+    result.Printf( "Map                Instances  Total Size Name\n" );
+    result.Printf( "------------------ ---------- ---------- ----\n" );
+
+    for (std::vector<TypeRecord*>::iterator it = sorted_by_count.begin();
+            it != sorted_by_count.end(); ++it) {
+        TypeRecord* t = *it;
+        result.Printf("0x%016" PRIx64 " %10" PRId64 " %10" PRId64 " %s\n",
+                t->map, t->instance_count, t->total_instance_size,
+                t->type_name->c_str());
+        total_objects += t->instance_count;
+    }
+
+    return true;
+}
+
+/* Utility function to generate short type names for objects.
+ * Based on the inspection code in llv8.cc
+ * TODO Merge back in to llv8.cc?
+ */
+std::string GetTypeName( llnode::v8::HeapObject *heap_object, v8::Value::InspectOptions *options, v8::Error err ) {
+  int64_t type = heap_object->GetType(err);
+  v8::LLV8 *v8 = heap_object->v8();
+  if (type == v8->types()->kGlobalObjectType) return heap_object->Inspect(options, err);
+  if (type == v8->types()->kCodeType) return heap_object->Inspect(options, err);
+  if (type == v8->types()->kMapType) {
+    return heap_object->Inspect(options, err);
+  }
+
+  if (type == v8->types()->kJSObjectType) {
+
+      llnode::v8::HeapObject map_obj = heap_object->GetMap(err);
+      if (err.Fail()) {
+          return std::string();
+      }
+
+      llnode::v8::Map map(map_obj);
+      llnode::v8::HeapObject constructor_obj = map.Constructor(err);
+      if (err.Fail()) {
+          return std::string();
+      }
+
+      int64_t constructor_type = constructor_obj.GetType(err);
+      if (err.Fail()) {
+          return std::string();
+      }
+
+      if (constructor_type != v8->types()->kJSFunctionType) {
+        return "<Object: no constructor>";
+      }
+
+      llnode::v8::JSFunction constructor(constructor_obj);
+
+      return constructor.Name(err);
+  }
+
+  if (type == v8->types()->kHeapNumberType) {
+    return "(HeapNumber)";
+  }
+
+  if (type == v8->types()->kJSArrayType) {
+    return "(Array)";
+  }
+
+  if (type == v8->types()->kOddballType) {
+    return "(Oddball)";
+  }
+
+  if (type == v8->types()->kJSFunctionType) {
+    return "(Function)";
+  }
+
+  if (type == v8->types()->kJSRegExpType) {
+    return "(RegExp)";
+  }
+
+  if (type < v8->types()->kFirstNonstringType) {
+    return "(String)";
+  }
+
+  if (type == v8->types()->kFixedArrayType) {
+    return "(FixedArray)";
+  }
+
+  if (type == v8->types()->kJSArrayBufferType) {
+    return "(ArrayBuffer)";
+  }
+
+  if (type == v8->types()->kJSTypedArrayType) {
+    return "(ArrayBufferView)";
+  }
+
+  if (type == v8->types()->kJSDateType) {
+    return "(Date)";
+  }
+
+  std::string unknown("unknown: ");
+
+  return unknown += std::to_string(type);
+}
+
+bool ListInstancesCmd::DoExecute(SBDebugger d, char** cmd,
+        SBCommandReturnObject& result) {
+    SBTarget target = d.GetSelectedTarget();
+    if (!target.IsValid()) {
+        result.SetError("No valid process, please start something\n");
+        return false;
+    }
+
+    v8::Value::InspectOptions inspect_options;
+
+    inspect_options.detailed = detailed_;
+
+    char** start = ParseInspectOptions(cmd, &inspect_options);
+
+    std::string full_cmd;
+    for (; start != nullptr && *start != nullptr; start++) full_cmd += *start;
+
+    SBExpressionOptions options;
+    SBValue value = target.EvaluateExpression(full_cmd.c_str(), options);
+    if (value.GetError().Fail()) {
+        SBStream desc;
+        if (!value.GetError().GetDescription(desc)) return false;
+        result.SetError(desc.GetData());
+        return false;
+    }
+
+    // Load V8 constants from postmortem data
+    llv8.Load(target);
+
+    v8::Value v8_mapaddr(&llv8, value.GetValueAsSigned());
+    v8::Error err;
+
+    if (err.Fail()) {
+        result.SetError("Failed to evaluate expression");
+        return false;
+    }
+
+    uint64_t mapaddr = value.GetValueAsUnsigned();
+    std::map<uint64_t, TypeRecord*>::iterator instance_it =
+            mapstoinstances->find(mapaddr);
+    if (instance_it != mapstoinstances->end()) {
+        TypeRecord* t = instance_it->second;
+        for (std::set<uint64_t>::iterator it = t->instances->begin();
+                it != t->instances->end(); ++it) {
+            v8::Error err;
+            v8::Value v8_value(&llv8, *it);
+            std::string res = v8_value.Inspect(&inspect_options, err);
+            result.Printf("%s\n", res.c_str());
+        }
+
+    } else {
+        result.Printf("No objects found with map %" PRIx64 "\n", mapaddr);
+    }
+
+    return true;
+
+}
+
+FindJSObjectsVisitor::FindJSObjectsVisitor(SBTarget* target,
+        SBCommandReturnObject* result) {
+    _target = target;
+    _result = result;
+    // Load V8 constants from postmortem data
+    llv8.Load(*target);
+    _address_byte_size = _target->GetProcess().GetAddressByteSize();
+    _found_count = 0;
+    mapstoinstances = new std::map<uint64_t, TypeRecord*>();
+}
+
+/* Visit every address, a bit brute force but it works. */
+uint64_t FindJSObjectsVisitor::Visit(uint64_t location, uint64_t available) {
+
+    lldb::SBError error;
+
+    // Test if the map points to a real map.
+    // Try to create an object out of it.
+
+    uint64_t word = _target->GetProcess().ReadUnsignedFromMemory(location,
+            _target->GetProcess().GetAddressByteSize(), error);
+
+    v8::Value v8_value(&llv8, word);
+
+    v8::Error err;
+    // Test if this is SMI
+    // Skip inspecting things that look like Smi's, they aren't objects.
+    llnode::v8::Smi smi(v8_value);
+    if (smi.Check()) {
+        return _address_byte_size;
+    }
+
+    llnode::v8::HeapObject heap_object(v8_value);
+    if (!heap_object.Check()) {
+        return _address_byte_size;
+    }
+    if (heap_object.IsHoleOrUndefined(err)) {
+        return _address_byte_size;
+    }
+    if (err.Fail()) {
+        return _address_byte_size;
+    }
+
+    llnode::v8::HeapObject map_object = heap_object.GetMap(err);
+    if (err.Fail() || !map_object.Check()) {
+        return _address_byte_size;
+    }
+
+    if( !IsAHistogramType(&heap_object, err) ) {
+        return _address_byte_size;
+    }
+
+    if (err.Fail()) {
+        return _address_byte_size;
+    }
+
+    llnode::v8::Map map(map_object);
+
+    v8::Value::InspectOptions inspect_options;
+    inspect_options.detailed = false;
+    inspect_options.print_map = false;
+    inspect_options.string_length = 0;
+
+    /* No entry in the map, create a new one. */
+    if (mapstoinstances->count(map_object.raw()) == 0) {
+        TypeRecord* t = new TypeRecord();
+        t->map = map_object.raw();
+        t->instance_count++;
+        // TODO - Do I need a better way to find the size of one instance of an object?
+        t->total_instance_size = map.InstanceSize(err);
+
+        t->type_name = new std::string(GetTypeName(&heap_object, &inspect_options, err));
+
+        mapstoinstances->insert(
+                std::pair<uint64_t, TypeRecord*>(map_object.raw(), t));
+        t->instances = new std::set<uint64_t>();
+    } else {
+        /* Update an existing instance, if we haven't seen this one before. */
+        TypeRecord* t = mapstoinstances->at(map_object.raw());
+        /* Determine if this is a new instance.
+         * (We are scanning pointers to objects, we may have seen this location before.)
+         */
+        if (t->instances->count(word) == 0) {
+            t->instances->insert(word);
+            t->instance_count++;
+            // TODO - Do I need a better way to find the size of one instance of an object?
+            t->total_instance_size += map.InstanceSize(err);
+        }
+    }
+
+    if (err.Fail()) {
+        return _address_byte_size;
+    }
+
+    _found_count++;
+
+    /* Just advance one word.
+     * (Should advance by object size, assuming objects can't overlap!)
+     */
+    return _address_byte_size;
+}
+
+bool FindJSObjectsVisitor::IsAHistogramType( llnode::v8::HeapObject *heap_object, v8::Error err ) {
+    int64_t type = heap_object->GetType(err);
+    v8::LLV8 *v8 = heap_object->v8();
+    if (type == v8->types()->kJSObjectType) return true;
+    if (type == v8->types()->kJSArrayType) return true;
+    if (type == v8->types()->kJSTypedArrayType) return true;
+    return false;
+}
+
+bool ScanHeapForObjects(lldb::SBTarget* target,
+        lldb::SBCommandReturnObject result) {
+
+    /* TODO - Check whether we have the SBGetMemoryRegionInfoList API available and implemented.
+     * (It may be available but not supported on this platform.)
+     * If it is then check the last scan is still valid - the process hasn't moved and we
+     * haven't changed target.
+     */
+
+    /* Fall back to environment variable containing pre-parsed list of memory ranges. */
+    if (nullptr == ranges) {
+
+        const char* segmentsfilename = getenv("RANGESFILE");
+
+        //
+        if (segmentsfilename == nullptr) {
+            //		  result.Printf("No memory ranges file. Plugin commands that need to scan addressable memory will fail.\n");
+            result.SetError(
+                    "No memory range information available for this process. Cannot scan for objects.\n");
+            return false;
+        }
+
+        if (!GenerateMemoryRanges(target, segmentsfilename)) {
+            result.SetError(
+                    "No memory range information available for this process. Cannot scan for objects.\n");
+            return false;
+        }
+    }
+
+    /* If we've reached here we have access to information about the valid memory ranges in the
+     * process and can scan for objects.
+     */
+
+    /* Populate the map of objects. */
+    if (mapstoinstances == NULL) {
+
+        FindJSObjectsVisitor v(target, &result);
+
+        ScanMemoryRanges(v);
+
+        result.Printf("Did search of memory - found %d pointers)\n",
+                v.FoundCount());
+
+    } else {
+        result.Printf("Re-using cached map\n");
+    }
+
+    return true;
+}
+
+void ScanMemoryRanges(MemoryVisitor &v) {
+
+    MemoryRange *head = ranges;
+
+    bool done = false;
+
+    while (head != nullptr && !done) {
+        uint64_t address = head->start;
+        uint64_t len = head->length;
+        head = head->next;
+
+        /* Brute force search - query every address - but allow the visitor code to say
+         * how far to move on so we don't read every byte.
+         */
+        for (auto searchAddress = address; searchAddress < address + len;) {
+            //		  result.Printf("Checking for needle at: 0x%" PRIx64 "\n", searchAddress);
+            //			  printf("Visiting address 0x%" PRIx64 "\n", searchAddress);
+            uint32_t increment = v.Visit(searchAddress,
+                    (address + len) - searchAddress);
+            if (increment == 0) {
+                done = true;
+                break;
+            }
+            searchAddress += increment;
+        }
+    }
+}
+
+/* Read a file of memory ranges parsed from the core dump.
+ * This is a work around for the lack of an API to get the memory ranges
+ * within lldb.
+ * There are scripts for generating this file on mac and linux stored as a snippet on github:
+ * https://gist.github.com/hhellyer/6d79009e142d6eef696525afe1ecea43
+ * export the name or full path to the ranges file in the RANGESFILE env var before starting
+ * lldb and loading the llnode plugin.
+ */
+bool GenerateMemoryRanges(lldb::SBTarget* target,
+        const char* segmentsfilename) {
+
+    std::ifstream input(segmentsfilename);
+
+    if (!input.is_open()) {
+        return false;
+    }
+
+    uint64_t address = 0, len = 0;
+
+    llnode::MemoryRange **tailptr = &llnode::ranges;
+
+    lldb::addr_t address_byte_size = target->GetProcess().GetAddressByteSize();
+
+    while (input >> std::hex >> address >> std::hex >> len) {
+
+        /* Check if the range is accessible.
+         * The structure of a core file means if you check the start and the end of a range then the
+         * middle will be there, ranges are contiguous in the file, but cores often get truncated due
+         * to file size limits so ranges can be missing or truncated. Sometimes shared memory segments
+         * are omitted so it's also possible an entire section could be missing from the middle.
+         */
+        lldb::SBError error;
+        target->GetProcess().ReadPointerFromMemory(address, error);
+        if (error.Success()) {
+            target->GetProcess().ReadPointerFromMemory(
+                    (address + len) - address_byte_size, error);
+
+            if (error.Success()) {
+                llnode::MemoryRange* newRange = new llnode::MemoryRange();
+                if (nullptr == newRange) {
+                    return false;
+                }
+                newRange->start = address;
+                newRange->length = len;
+                newRange->next = nullptr;
+                (*tailptr) = newRange;
+                tailptr = &(newRange->next);
+
+            } else {
+                /* Could not access last word, skip. */
+            }
+        } else {
+            /* Could not access first word, skip. */
+        }
+
+    }
+    return true;
+
+}
+
+}
+

--- a/src/llscan.h
+++ b/src/llscan.h
@@ -84,7 +84,7 @@ class LLScan {
   std::string GetTypeName(v8::HeapObject& heap_object,
                           v8::Value::InspectOptions& options, v8::Error err);
   bool ScanHeapForObjects(lldb::SBTarget target,
-                          lldb::SBCommandReturnObject result);
+                          lldb::SBCommandReturnObject &result);
   bool GenerateMemoryRanges(lldb::SBTarget target,
                             const char* segmentsfilename);
 

--- a/src/llscan.h
+++ b/src/llscan.h
@@ -1,0 +1,89 @@
+#ifndef SRC_LLSCAN_H_
+#define SRC_LLSCAN_H_
+
+#include <lldb/API/LLDB.h>
+#include <map>
+#include <set>
+
+namespace llnode {
+
+class ListObjectsCmd : public CommandBase {
+ public:
+  ~ListObjectsCmd() override {}
+
+  bool DoExecute(lldb::SBDebugger d, char** cmd,
+                 lldb::SBCommandReturnObject& result) override;
+
+};
+
+class ListInstancesCmd : public CommandBase {
+ public:
+  ~ListInstancesCmd() override {}
+
+  bool DoExecute(lldb::SBDebugger d, char** cmd,
+                 lldb::SBCommandReturnObject& result) override;
+
+ private:
+  bool detailed_;
+};
+
+class MemoryVisitor {
+ public:
+  virtual ~MemoryVisitor() {};
+
+  virtual uint64_t Visit(uint64_t location, uint64_t available) {return 0;};
+
+};
+
+class TypeRecord {
+public:
+	uint64_t map;
+	std::string* type_name;
+	uint64_t property_count;
+	uint64_t instance_count;
+	uint64_t total_instance_size;
+	std::set<uint64_t> *instances;
+
+	/* Sort records by instance count, use the other fields as tie breakers
+	 * to give consistent ordering.
+	 */
+	static bool compareInstanceCounts(TypeRecord* a, TypeRecord* b) {
+	    if( a->instance_count == b->instance_count) {
+	        if( a->total_instance_size == b->total_instance_size ) {
+	            return a->type_name < b->type_name;
+	        }
+	        return a->total_instance_size < b->total_instance_size;
+	    }
+		return a->instance_count < b-> instance_count;
+	}
+};
+
+class FindJSObjectsVisitor : public MemoryVisitor {
+ public:
+  FindJSObjectsVisitor(lldb::SBTarget* target, lldb::SBCommandReturnObject* result);
+  ~FindJSObjectsVisitor() {}
+
+  uint64_t Visit(uint64_t location, uint64_t available);
+
+  uint32_t FoundCount() { return _found_count; }
+
+ private:
+
+  bool IsAHistogramType( llnode::v8::HeapObject *heap_object, v8::Error err );
+
+  lldb::SBTarget* _target;
+  lldb::SBCommandReturnObject* _result;
+  uint32_t _address_byte_size;
+  uint32_t _found_count;
+
+};
+
+std::string GetTypeName( llnode::v8::HeapObject *heap_object, v8::Value::InspectOptions *options, v8::Error err );
+bool ScanHeapForObjects(lldb::SBTarget* target, lldb::SBCommandReturnObject result);
+bool GenerateMemoryRanges(lldb::SBTarget* target, const char* segmentsfilename);
+void ScanMemoryRanges(MemoryVisitor &v);
+
+} //llnode
+
+
+#endif  // SRC_LLSCAN_H_

--- a/src/llscan.h
+++ b/src/llscan.h
@@ -13,7 +13,6 @@ class ListObjectsCmd : public CommandBase {
 
   bool DoExecute(lldb::SBDebugger d, char** cmd,
                  lldb::SBCommandReturnObject& result) override;
-
 };
 
 class ListInstancesCmd : public CommandBase {
@@ -29,61 +28,86 @@ class ListInstancesCmd : public CommandBase {
 
 class MemoryVisitor {
  public:
-  virtual ~MemoryVisitor() {};
+  virtual ~MemoryVisitor(){};
 
-  virtual uint64_t Visit(uint64_t location, uint64_t available) {return 0;};
-
+  virtual uint64_t Visit(uint64_t location, uint64_t available) { return 0; };
 };
 
 class TypeRecord {
-public:
-	uint64_t map;
-	std::string* type_name;
-	uint64_t property_count;
-	uint64_t instance_count;
-	uint64_t total_instance_size;
-	std::set<uint64_t> *instances;
+ public:
+  uint64_t map;
+  std::string* type_name;
+  uint64_t property_count;
+  uint64_t instance_count;
+  uint64_t total_instance_size;
+  std::set<uint64_t>* instances;
 
-	/* Sort records by instance count, use the other fields as tie breakers
-	 * to give consistent ordering.
-	 */
-	static bool compareInstanceCounts(TypeRecord* a, TypeRecord* b) {
-	    if( a->instance_count == b->instance_count) {
-	        if( a->total_instance_size == b->total_instance_size ) {
-	            return a->type_name < b->type_name;
-	        }
-	        return a->total_instance_size < b->total_instance_size;
-	    }
-		return a->instance_count < b-> instance_count;
-	}
+  /* Sort records by instance count, use the other fields as tie breakers
+   * to give consistent ordering.
+   */
+  static bool compareInstanceCounts(TypeRecord* a, TypeRecord* b) {
+    if (a->instance_count == b->instance_count) {
+      if (a->total_instance_size == b->total_instance_size) {
+        return a->type_name < b->type_name;
+      }
+      return a->total_instance_size < b->total_instance_size;
+    }
+    return a->instance_count < b->instance_count;
+  }
 };
 
-class FindJSObjectsVisitor : public MemoryVisitor {
+class FindJSObjectsVisitor : MemoryVisitor {
  public:
-  FindJSObjectsVisitor(lldb::SBTarget* target, lldb::SBCommandReturnObject* result);
+  FindJSObjectsVisitor(lldb::SBTarget& target,
+                       std::map<uint64_t, TypeRecord*>& mapstoinstances);
   ~FindJSObjectsVisitor() {}
 
   uint64_t Visit(uint64_t location, uint64_t available);
 
-  uint32_t FoundCount() { return _found_count; }
+  uint32_t FoundCount() { return found_count_; }
 
  private:
+  bool IsAHistogramType(v8::HeapObject& heap_object, v8::Error err);
 
-  bool IsAHistogramType( llnode::v8::HeapObject *heap_object, v8::Error err );
+  lldb::SBTarget& target_;
+  uint32_t address_byte_size_;
+  uint32_t found_count_;
 
-  lldb::SBTarget* _target;
-  lldb::SBCommandReturnObject* _result;
-  uint32_t _address_byte_size;
-  uint32_t _found_count;
-
+  std::map<uint64_t, TypeRecord*>& mapstoinstances_;
 };
 
-std::string GetTypeName( llnode::v8::HeapObject *heap_object, v8::Value::InspectOptions *options, v8::Error err );
-bool ScanHeapForObjects(lldb::SBTarget* target, lldb::SBCommandReturnObject result);
-bool GenerateMemoryRanges(lldb::SBTarget* target, const char* segmentsfilename);
-void ScanMemoryRanges(MemoryVisitor &v);
 
-} //llnode
+class LLScan {
+ public:
+  LLScan(){};
+
+  std::string GetTypeName(v8::HeapObject& heap_object,
+                          v8::Value::InspectOptions& options, v8::Error err);
+  bool ScanHeapForObjects(lldb::SBTarget target,
+                          lldb::SBCommandReturnObject result);
+  bool GenerateMemoryRanges(lldb::SBTarget target,
+                            const char* segmentsfilename);
+
+  std::map<uint64_t, TypeRecord*>& GetMapsToInstances() {
+    return mapstoinstances_;
+  };
+
+ private:
+  void ScanMemoryRanges(FindJSObjectsVisitor& v);
+
+  struct MemoryRange {
+    uint64_t start;
+    uint64_t length;
+    MemoryRange* next;
+  };
+
+  lldb::SBTarget target_;
+  lldb::SBProcess process_;
+  MemoryRange* ranges_ = nullptr;
+  std::map<uint64_t, TypeRecord*> mapstoinstances_;
+};
+
+}  // llnode
 
 
 #endif  // SRC_LLSCAN_H_

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -1,8 +1,8 @@
 #include <assert.h>
 #include <inttypes.h>
 
-#include "llv8.h"
 #include "llv8-inl.h"
+#include "llv8.h"
 
 namespace llnode {
 namespace v8 {
@@ -549,6 +549,20 @@ std::string Value::Inspect(InspectOptions* options, Error& err) {
 }
 
 
+std::string Value::GetTypeName(InspectOptions* options, Error& err) {
+  Smi smi(this);
+  if (smi.Check()) return smi.Inspect(err);
+
+  HeapObject obj(this);
+  if (!obj.Check()) {
+    err = Error::Failure("Not object and not smi");
+    return std::string();
+  }
+
+  return obj.GetTypeName(options, err);
+}
+
+
 std::string Value::ToString(Error& err) {
   Smi smi(this);
   if (smi.Check()) return smi.ToString(err);
@@ -669,6 +683,88 @@ std::string Smi::ToString(Error& err) {
   snprintf(buf, sizeof(buf), "%d", static_cast<int>(GetValue()));
   err = Error::Ok();
   return buf;
+}
+
+
+/* Utility function to generate short type names for objects.
+ */
+std::string HeapObject::GetTypeName(InspectOptions* options, Error& err) {
+  int64_t type = GetType(err);
+  if (type == v8()->types()->kGlobalObjectType) return Inspect(options, err);
+  if (type == v8()->types()->kCodeType) return Inspect(options, err);
+  if (type == v8()->types()->kMapType) {
+    return Inspect(options, err);
+  }
+
+  if (type == v8()->types()->kJSObjectType) {
+    v8::HeapObject map_obj = GetMap(err);
+    if (err.Fail()) {
+      return std::string();
+    }
+
+    v8::Map map(map_obj);
+    v8::HeapObject constructor_obj = map.Constructor(err);
+    if (err.Fail()) {
+      return std::string();
+    }
+
+    int64_t constructor_type = constructor_obj.GetType(err);
+    if (err.Fail()) {
+      return std::string();
+    }
+
+    if (constructor_type != v8()->types()->kJSFunctionType) {
+      return "<Object: no constructor>";
+    }
+
+    v8::JSFunction constructor(constructor_obj);
+
+    return constructor.Name(err);
+  }
+
+  if (type == v8()->types()->kHeapNumberType) {
+    return "(HeapNumber)";
+  }
+
+  if (type == v8()->types()->kJSArrayType) {
+    return "(Array)";
+  }
+
+  if (type == v8()->types()->kOddballType) {
+    return "(Oddball)";
+  }
+
+  if (type == v8()->types()->kJSFunctionType) {
+    return "(Function)";
+  }
+
+  if (type == v8()->types()->kJSRegExpType) {
+    return "(RegExp)";
+  }
+
+  if (type < v8()->types()->kFirstNonstringType) {
+    return "(String)";
+  }
+
+  if (type == v8()->types()->kFixedArrayType) {
+    return "(FixedArray)";
+  }
+
+  if (type == v8()->types()->kJSArrayBufferType) {
+    return "(ArrayBuffer)";
+  }
+
+  if (type == v8()->types()->kJSTypedArrayType) {
+    return "(ArrayBufferView)";
+  }
+
+  if (type == v8()->types()->kJSDateType) {
+    return "(Date)";
+  }
+
+  std::string unknown("unknown: ");
+
+  return unknown + std::to_string(type);
 }
 
 

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -551,7 +551,7 @@ std::string Value::Inspect(InspectOptions* options, Error& err) {
 
 std::string Value::GetTypeName(InspectOptions* options, Error& err) {
   Smi smi(this);
-  if (smi.Check()) return smi.Inspect(err);
+  if (smi.Check()) return "(Smi)";
 
   HeapObject obj(this);
   if (!obj.Check()) {
@@ -690,10 +690,10 @@ std::string Smi::ToString(Error& err) {
  */
 std::string HeapObject::GetTypeName(InspectOptions* options, Error& err) {
   int64_t type = GetType(err);
-  if (type == v8()->types()->kGlobalObjectType) return Inspect(options, err);
-  if (type == v8()->types()->kCodeType) return Inspect(options, err);
+  if (type == v8()->types()->kGlobalObjectType) return "(Global)";
+  if (type == v8()->types()->kCodeType) return "(Code)";
   if (type == v8()->types()->kMapType) {
-    return Inspect(options, err);
+    return "(Map)";
   }
 
   if (type == v8()->types()->kJSObjectType) {
@@ -714,7 +714,7 @@ std::string HeapObject::GetTypeName(InspectOptions* options, Error& err) {
     }
 
     if (constructor_type != v8()->types()->kJSFunctionType) {
-      return "<Object: no constructor>";
+      return "(Object)";
     }
 
     v8::JSFunction constructor(constructor_obj);

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -8,6 +8,9 @@
 #include "src/llv8-constants.h"
 
 namespace llnode {
+
+class FindJSObjectsVisitor;
+
 namespace v8 {
 
 // Forward declarations
@@ -67,6 +70,7 @@ class Value {
   bool IsHole(Error& err);
 
   std::string Inspect(InspectOptions* options, Error& err);
+  std::string GetTypeName(InspectOptions* options, Error& err);
   std::string ToString(Error& err);
 
  protected:
@@ -101,6 +105,7 @@ class HeapObject : public Value {
 
   std::string ToString(Error& err);
   std::string Inspect(InspectOptions* options, Error& err);
+  std::string GetTypeName(InspectOptions* options, Error& err);
 };
 
 class Map : public HeapObject {
@@ -403,8 +408,6 @@ class LLV8 {
 
   void Load(lldb::SBTarget target);
 
-  constants::Types types;
-
  private:
   template <class T>
   inline T LoadValue(int64_t addr, Error& err);
@@ -447,6 +450,7 @@ class LLV8 {
   constants::DescriptorArray descriptor_array;
   constants::NameDictionary name_dictionary;
   constants::Frame frame;
+  constants::Types types;
 
 
   friend class Value;
@@ -478,6 +482,7 @@ class LLV8 {
   friend class JSRegExp;
   friend class JSDate;
   friend class CodeMap;
+  friend class llnode::FindJSObjectsVisitor;
 };
 
 #undef V8_VALUE_DEFAULT_METHODS

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -452,7 +452,6 @@ class LLV8 {
   constants::Frame frame;
   constants::Types types;
 
-
   friend class Value;
   friend class JSFrame;
   friend class Smi;

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -403,6 +403,8 @@ class LLV8 {
 
   void Load(lldb::SBTarget target);
 
+  constants::Types types;
+
  private:
   template <class T>
   inline T LoadValue(int64_t addr, Error& err);
@@ -445,7 +447,7 @@ class LLV8 {
   constants::DescriptorArray descriptor_array;
   constants::NameDictionary name_dictionary;
   constants::Frame frame;
-  constants::Types types;
+
 
   friend class Value;
   friend class JSFrame;


### PR DESCRIPTION
This branch provides a command to list the objects in a dump grouped by type (map) and to dump all the instances of objects which share a particular map.

It needs the user to run one of the supplied scripts to generate a file of memory regions and them to export the name of that file in the RANGESFILE environment variable. (The readelf script should be run on linux, the otool one on Mac OSX.)

This restriction can be lifted once the lldb API is updated but only requires the code for walking memory to change as I’ve isolated that from the code which actually identifies objects. I think the walking memory code could probably be updated to improve performances as well as currently the memory is walked a word at a time.

Please feel free to suggest improvements and alterations or any bugs.