### PR TITLE
Enable findjsobject/findjsinstances to use the SBMemoryRegionInfo API

### DIFF
--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -277,6 +277,7 @@ bool LLScan::ScanHeapForObjects(lldb::SBTarget target,
 
 
 void LLScan::ScanMemoryRanges(FindJSObjectsVisitor& v) {
+  bool done = false;
 
 #if !defined(LLDB_SBMemoryRegionInfoList_h_)
   MemoryRange* head = ranges_;
@@ -303,6 +304,7 @@ void LLScan::ScanMemoryRanges(FindJSObjectsVisitor& v) {
       uint32_t increment =
           v.Visit(searchAddress, (address + len) - searchAddress);
       if (increment == 0) {
+        done = true;
         break;
       }
       searchAddress += increment;

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -238,7 +238,7 @@ bool LLScan::ScanHeapForObjects(lldb::SBTarget target,
     target_ = target;
   }
 
-#if !defined(LLDB_SBMemoryRegionInfoList_h_)
+#ifndef LLDB_SBMemoryRegionInfoList_h_
   /* Fall back to environment variable containing pre-parsed list of memory
    * ranges. */
   if (nullptr == ranges_) {
@@ -279,7 +279,7 @@ bool LLScan::ScanHeapForObjects(lldb::SBTarget target,
 void LLScan::ScanMemoryRanges(FindJSObjectsVisitor& v) {
   bool done = false;
 
-#if !defined(LLDB_SBMemoryRegionInfoList_h_)
+#ifndef LLDB_SBMemoryRegionInfoList_h_
   MemoryRange* head = ranges_;
 
   while (head != nullptr && !done) {
@@ -287,7 +287,7 @@ void LLScan::ScanMemoryRanges(FindJSObjectsVisitor& v) {
     uint64_t len = head->length_;
     head = head->next_;
 
-# else
+# else // LLDB_SBMemoryRegionInfoList_h_
   SBMemoryRegionInfoList memory_regions = process_.GetMemoryRegions();
   SBMemoryRegionInfo region_info;
 
@@ -296,7 +296,7 @@ void LLScan::ScanMemoryRanges(FindJSObjectsVisitor& v) {
     uint64_t address = region_info.GetRegionBase();
     uint64_t len = region_info.GetRegionEnd() - region_info.GetRegionBase();
 
-#endif
+#endif // LLDB_SBMemoryRegionInfoList_h_
     /* Brute force search - query every address - but allow the visitor code to
      * say how far to move on so we don't read every byte.
      */

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -222,11 +222,7 @@ bool FindJSObjectsVisitor::IsAHistogramType(v8::HeapObject& heap_object,
 
 bool LLScan::ScanHeapForObjects(lldb::SBTarget target,
                                 lldb::SBCommandReturnObject& result) {
-  /* TODO(hhellyer) - Check whether we have the SBGetMemoryRegionInfoList API
-   * available
-   * and implemented.
-   * (It may be available but not supported on this platform.)
-   * If it is then check the last scan is still valid - the process hasn't moved
+  /* Check the last scan is still valid - the process hasn't moved
    * and we haven't changed target.
    */
 
@@ -238,8 +234,11 @@ bool LLScan::ScanHeapForObjects(lldb::SBTarget target,
   // LLNODE_RANGESFILE with data for the new dump or things won't match up).
   if (target_ != target) {
     ClearMemoryRanges();
+    mapstoinstances_.clear();
+    target_ = target;
   }
 
+#if !defined(LLDB_SBMemoryRegionInfoList_h_)
   /* Fall back to environment variable containing pre-parsed list of memory
    * ranges. */
   if (nullptr == ranges_) {
@@ -260,10 +259,10 @@ bool LLScan::ScanHeapForObjects(lldb::SBTarget target,
       return false;
     }
   }
+#endif // LLDB_SBMemoryRegionInfoList_h_
 
   /* If we've reached here we have access to information about the valid memory
-   * ranges in the
-   * process and can scan for objects.
+   * ranges in the process and can scan for objects.
    */
 
   /* Populate the map of objects. */
@@ -278,24 +277,32 @@ bool LLScan::ScanHeapForObjects(lldb::SBTarget target,
 
 
 void LLScan::ScanMemoryRanges(FindJSObjectsVisitor& v) {
-  MemoryRange* head = ranges_;
 
-  bool done = false;
+#if !defined(LLDB_SBMemoryRegionInfoList_h_)
+  MemoryRange* head = ranges_;
 
   while (head != nullptr && !done) {
     uint64_t address = head->start_;
     uint64_t len = head->length_;
     head = head->next_;
 
+# else
+  SBMemoryRegionInfoList memory_regions = process_.GetMemoryRegions();
+  SBMemoryRegionInfo region_info;
+
+  for( uint32_t i = 0; i < memory_regions.GetSize(); ++i ) {
+    memory_regions.GetMemoryRegionAtIndex(i, region_info);
+    uint64_t address = region_info.GetRegionBase();
+    uint64_t len = region_info.GetRegionEnd() - region_info.GetRegionBase();
+
+#endif
     /* Brute force search - query every address - but allow the visitor code to
-     * say
-     * how far to move on so we don't read every byte.
+     * say how far to move on so we don't read every byte.
      */
     for (auto searchAddress = address; searchAddress < address + len;) {
       uint32_t increment =
           v.Visit(searchAddress, (address + len) - searchAddress);
       if (increment == 0) {
-        done = true;
         break;
       }
       searchAddress += increment;
@@ -367,5 +374,16 @@ void LLScan::ClearMemoryRanges() {
     delete range;
   }
   ranges_ = nullptr;
+}
+
+
+void LLScan::ClearMapsToInstances() {
+  TypeRecordMap::iterator end = GetMapsToInstances().end();
+  for (TypeRecordMap::iterator it = GetMapsToInstances().begin();
+      it != end; ++it) {
+    TypeRecord* t = it->second;
+    delete t;
+  }
+  GetMapsToInstances().clear();
 }
 }

--- a/src/llscan.h
+++ b/src/llscan.h
@@ -106,6 +106,7 @@ class LLScan {
  private:
   void ScanMemoryRanges(FindJSObjectsVisitor& v);
   void ClearMemoryRanges();
+  void ClearMapsToInstances();
 
   class MemoryRange {
    public:


### PR DESCRIPTION
This patch enables LLNode to detect the SBMemoryRegionInfo API in LLDB at compile time. If it is present then LLNode will be compiled to use it and LLNODE_RANGESFILE won’t be needed in order to run findjsobjects.

Currently this will only work against a version of LLDB build from the current head of the LLDB development stream and the resulting plugin will only work with an lldb executable compiled from that.

I don’t know when the next level of LLDB, which hopefully should include the new API, will be released. I’m happy for this pull request to go on ice until then if you don't want support for unreleased function enabled yet - I really didn’t want it to only exist on my laptop!