### PR TITLE
PrintCmd - avoid crash when no options are passed to command.

### DIFF
--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -115,6 +115,15 @@ bool BacktraceCmd::DoExecute(SBDebugger d, char** cmd,
 
 bool PrintCmd::DoExecute(SBDebugger d, char** cmd,
                          SBCommandReturnObject& result) {
+  if (*cmd == NULL) {
+    if( detailed_ ) {
+      result.SetError("USAGE: v8 inspect [flags] expr\n");
+    } else {
+      result.SetError("USAGE: v8 print expr\n");
+    }
+    return false;
+  }
+
   SBTarget target = d.GetSelectedTarget();
   if (!target.IsValid()) {
     result.SetError("No valid process, please start something\n");


### PR DESCRIPTION
PR #15 fixed a bug in my findjsinstances parameter handling code which could cause a crash when no options were passed, unfortunately I used the same code as the v8 inspect command!
This change applies the same fix back to that and displays the help when no parameters are passed.