### PR TITLE
nodeinfo command to show basic information about the process

### DIFF
--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -311,6 +311,11 @@ bool PluginInitialize(SBDebugger d) {
   interpreter.AddCommand("findjsinstances", new llnode::FindInstancesCmd(),
                          "List all objects which share the specified map.\n");
 
+  v8.AddCommand("nodeinfo", new llnode::NodeInfoCmd(),
+                "Print information about Node.js\n");
+
+  interpreter.AddCommand("nodeinfo", new llnode::NodeInfoCmd(),
+                         "Print information about Node.js\n");
 
   return true;
 }

--- a/src/llscan.h
+++ b/src/llscan.h
@@ -26,6 +26,14 @@ class FindInstancesCmd : public CommandBase {
   bool detailed_;
 };
 
+class NodeInfoCmd : public CommandBase {
+ public:
+  ~NodeInfoCmd() override{};
+
+  bool DoExecute(lldb::SBDebugger d, char** cmd,
+                 lldb::SBCommandReturnObject& result) override;
+};
+
 class MemoryVisitor {
  public:
   virtual ~MemoryVisitor(){};

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -232,13 +232,23 @@ class JSObject : public HeapObject {
   std::string Inspect(InspectOptions* options, Error& err);
   std::string InspectProperties(Error& err);
 
- protected:
-  template <class T>
-  T GetInObjectValue(int64_t size, int index, Error& err);
-
   std::string InspectElements(Error& err);
   std::string InspectDictionary(Error& err);
   std::string InspectDescriptors(Map map, Error& err);
+  void Keys(std::vector<std::string>& keys, Error& err);
+  Value GetProperty(std::string key_name, Error& err);
+  int64_t GetArrayLength(Error& err);
+  Value GetArrayElement(int64_t pos, Error& err);
+
+
+ protected:
+  template <class T>
+  T GetInObjectValue(int64_t size, int index, Error& err);
+  void ElementKeys(std::vector<std::string>& keys, Error& err);
+  void DictionaryKeys(std::vector<std::string>& keys, Error& err);
+  void DescriptorKeys(std::vector<std::string>& keys, Map map, Error& err);
+  Value GetDictionaryProperty(std::string key_name, Error& err);
+  Value GetDescriptorProperty(std::string key_name, Map map, Error& err);
 };
 
 class JSArray : public JSObject {


### PR DESCRIPTION
This PR uses the heap walk we are already doing to make it easy to view the contents of the process object. That lets us tell the user helpful things like what version of node they were running, what options and what script. (Output below.)

Doing this required adding some accessor functions based on the inspection code that let you navigate around objects rather than format them to strings. Those are in llv8.cc/.h.

The command has been added as “v8 nodeinfo” or just “nodeinfo” but I’m actually unsure whether it should be under “v8” at all as the process object is part of node.

I’m happy to make changes to the code or the output based on any feedback.

Sample output:
```
Information for process id 5780 (process=0x115a1f08469)
Platform = darwin, Architecture = x64, Node Version = v4.4.7
Component versions (process.versions=0x115a1f256b9):
    ares = 1.10.1-DEV
    http_parser = 2.5.2
    icu = 56.1
    modules = 46
    node = 4.4.7
    openssl = 1.0.2h
    uv = 1.8.0
    v8 = 4.5.103.36
    zlib = 1.2.8
Release Info (process.release=0x115a1f25729):
    name = node
    lts = Argon
    sourceUrl = https://nodejs.org/download/release/v4.4.7/node-v4.4.7.tar.gz
    headersUrl = https://nodejs.org/download/release/v4.4.7/node-v4.4.7-headers.tar.gz
Executable Path = [somedir]/node-v4.4.7-darwin-x64/bin/node
Command line arguments (process.argv=0x115a1f25831):
    [0] = '[somedir]/node-v4.4.7-darwin-x64/bin/node'
    [1] = '[somedir]/testscripts/print_info_and_crash.js'
Node.js Comamnd line arguments (process.execArgv=0x115a1f257f1):
    [0] = '--abort-on-uncaught-exception'
```