### PR TITLE
llnode: set SBCommandReturnObject result status

### DIFF
--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -109,6 +109,7 @@ bool BacktraceCmd::DoExecute(SBDebugger d, char** cmd,
                   res.c_str());
   }
 
+  result.SetStatus(eReturnStatusSuccessFinishResult);
   return true;
 }
 
@@ -143,8 +144,10 @@ bool PrintCmd::DoExecute(SBDebugger d, char** cmd,
   SBValue value = target.EvaluateExpression(full_cmd.c_str(), options);
   if (value.GetError().Fail()) {
     SBStream desc;
-    if (!value.GetError().GetDescription(desc)) return false;
-    result.SetError(desc.GetData());
+    if (value.GetError().GetDescription(desc)) {
+      result.SetError(desc.GetData());
+    }
+    result.SetStatus(eReturnStatusFailed);
     return false;
   }
 
@@ -160,7 +163,7 @@ bool PrintCmd::DoExecute(SBDebugger d, char** cmd,
   }
 
   result.Printf("%s\n", res.c_str());
-
+  result.SetStatus(eReturnStatusSuccessFinishResult);
   return true;
 }
 
@@ -245,7 +248,7 @@ bool ListCmd::DoExecute(SBDebugger d, char** cmd,
     result.Printf("  %d %s\n", line_cursor - lines_found + i + 1,
                   lines[i].c_str());
   }
-
+  result.SetStatus(eReturnStatusSuccessFinishResult);
   return true;
 }
 

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -34,6 +34,7 @@ bool FindObjectsCmd::DoExecute(SBDebugger d, char** cmd,
 
   /* Ensure we have a map of objects. */
   if (!llscan.ScanHeapForObjects(target, result)) {
+    result.SetStatus(eReturnStatusFailed);
     return false;
   }
 
@@ -63,6 +64,7 @@ bool FindObjectsCmd::DoExecute(SBDebugger d, char** cmd,
     total_objects += t->GetInstanceCount();
   }
 
+  result.SetStatus(eReturnStatusSuccessFinishResult);
   return true;
 }
 
@@ -108,8 +110,11 @@ bool FindInstancesCmd::DoExecute(SBDebugger d, char** cmd,
 
   } else {
     result.Printf("No objects found with type name %s\n", type_name.c_str());
+    result.SetStatus(eReturnStatusFailed);
+    return false;
   }
 
+  result.SetStatus(eReturnStatusSuccessFinishResult);
   return true;
 }
 


### PR DESCRIPTION
`SBCommandReturnObject::Succeeded()` always return `false`, when I check return result.

The existing llnode code works OK in the lldb line-mode tool,
maybe that does not check the return status.
Anyway, should be fixed, also for the other commands.
Here set SBCommandReturnObject status when failed or success.

@rnchamberlain @indutny 