### PR TITLE
llnode: remove nodeinfo shortcut

### DIFF
--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -314,9 +314,6 @@ bool PluginInitialize(SBDebugger d) {
   v8.AddCommand("nodeinfo", new llnode::NodeInfoCmd(),
                 "Print information about Node.js\n");
 
-  interpreter.AddCommand("nodeinfo", new llnode::NodeInfoCmd(),
-                         "Print information about Node.js\n");
-
   return true;
 }
 


### PR DESCRIPTION
The nodeinfo command has no equivalent in mdb_v8, removing the
shortcut and leaving it under the v8 namespace.