### PR TITLE
src: use `cinttypes` to fix CentOS

### DIFF
--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -1,9 +1,9 @@
 #include <errno.h>
-#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include <algorithm>
+#include <cinttypes>
 #include <fstream>
 #include <vector>
 

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -1,5 +1,6 @@
 #include <assert.h>
-#include <inttypes.h>
+
+#include <cinttypes>
 
 #include "llv8-inl.h"
 #include "llv8.h"


### PR DESCRIPTION
Otherwise it fails with:

    error: expected ‘)’ before ‘PRIx64’

Fix: #22