### PR TITLE
Add strings to the histogram of objects on the heap.

### DIFF
--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -391,6 +391,7 @@ bool FindJSObjectsVisitor::IsAHistogramType(v8::HeapObject& heap_object,
   if (type == v8->types()->kJSObjectType) return true;
   if (type == v8->types()->kJSArrayType) return true;
   if (type == v8->types()->kJSTypedArrayType) return true;
+  if (type < v8->types()->kFirstNonstringType) return true;
   return false;
 }
 


### PR DESCRIPTION
This is for issue #27 .
I noticed it while working on adding the findrefs command but wanted to keep this separate from those changes as it alters the behaviour of findjsobjects. (It's useful for findrefs because you may want to identify what is referring to a particular string.)