### PR TITLE
llv8: fix `WasNeutered` check

### DIFF
--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -359,9 +359,10 @@ void JSArrayBuffer::Load() {
     common_->Load();
 
     kBackingStoreOffset = kByteLengthOffset + common_->kPointerSize;
-    kBitFieldOffset = kBackingStoreOffset + common_->kPointerSize;
-    if (common_->kPointerSize == 8) kBitFieldOffset += 4;
   }
+
+  kBitFieldOffset = kBackingStoreOffset + common_->kPointerSize;
+  if (common_->kPointerSize == 8) kBitFieldOffset += 4;
 
   kWasNeuteredMask = LoadConstant("jsarray_buffer_was_neutered_mask");
   kWasNeuteredShift = LoadConstant("jsarray_buffer_was_neutered_shift");


### PR DESCRIPTION
The `kBitFieldOffset` was loaded conditionally, why it needs to be
computed for all versions of V8.

R= @hhellyer or @yjhjstz (PTAL)